### PR TITLE
Adding validation for users' names

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,12 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
   has_many :messages
   has_many :groups, through: :members
   has_many :members
+
+  validates :name, presence: true
+  validates :name, uniqueness: true
 
 end


### PR DESCRIPTION
# What
ユーザーの名前は必ずなければならないようにする。

# Why
現時点では、ユーザーネームのないユーザーを作成できてしまうため。