### PR TITLE
Changing a time zone to that in Tokyo

### DIFF
--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,7 +1,7 @@
 .message
   .message__upper
     .message__upper-name= message.user.name
-    .message__upper-time= message.created_at
+    .message__upper-time= message.created_at.strftime("%Y/%m/%d %H:%M")
   .message__lower
     .message__lower-body= message.body
     = image_tag message.image_url, class: 'message__lower-image' if message.image.present?

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ module ChatSpace
       g.helper false
       g.test_framework false
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ module ChatSpace
       g.test_framework false
     config.i18n.default_locale = :ja
     config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
     end
   end
 end


### PR DESCRIPTION
# What
To change a time zone to that in Tokyo.

# Why
Currently, UTC is used as a time zone. However, at this moment, I expect this web service to be used by people in Japan. Thus, JST should be used instead.