### PR TITLE
Adding a character limit to users' names and groups' names

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,7 +2,7 @@ class Group < ApplicationRecord
   has_many :messages
   has_many :users, through: :members
   has_many :members
-  validates :name, presence: true
+  validates :name, presence: true, length: {maximum: 50 }
 
   def show_latest_message(user_group)
     if (latest_message = user_group.messages.first).present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   has_many :groups, through: :members
   has_many :members
 
-  validates :name, presence: true
+  validates :name, presence: true, length: {maximum: 13}
   validates :name, uniqueness: true
 
 end


### PR DESCRIPTION
# What
To add a character limit to users' names and groups' names.

# Why
ユーザーネームやグループネームが極端に長いと、それが表示される際にレイアウトが崩れることがあるため。