### PR TITLE
Solving-an-existing-error-related-to-the-sidebar

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -13,6 +13,7 @@ class MessagesController < ApplicationController
       redirect_to group_messages_path(@group), notice: 'メッセージを送信しました。'
     else
       @messages = @group.messages.includes(:user)
+      @groups = current_user.groups.includes(:messages).order("messages.created_at desc")
       render :index
     end
 


### PR DESCRIPTION
# what
メッセージの送信に失敗したとき（テキストも画像もない状態でSendボタンを押したときなど）に、サイドバーから所属しているグループの一覧の表示が消えてしまう問題を解決。

# Why
メッセージの送信に失敗した場合でも、サイドバーにはカーレント・ユーザーが所属しているグループの一覧を表示させたいから。