### PR TITLE
Removing character limit of user names

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,6 @@ class User < ApplicationRecord
   has_many :groups, through: :members
   has_many :members
 
-  validates :name, presence: true,uniqueness: true, length: {maximum: 13}
+  validates :name, presence: true,uniqueness: true
 
 end


### PR DESCRIPTION
# What
Userのnameに付いている文字数制限のバリデーションを外す。

# Why
現在は、ユーザーのnameに13字以内という文字数制限が付いているが、英名だと13字は短すぎるから。