### PR TITLE
Deleting a migration file causing errors

### DIFF
--- a/db/migrate/20190203042329_delete_members_table.rb
+++ b/db/migrate/20190203042329_delete_members_table.rb
@@ -1,8 +1,0 @@
-class DeleteMembersTable < ActiveRecord::Migration[5.0]
-  def up
-    drop_table :members
-  end
-
-  def down
-  end
-end

--- a/db/migrate/20190203042329_delete_members_table.rb
+++ b/db/migrate/20190203042329_delete_members_table.rb
@@ -1,5 +1,8 @@
 class DeleteMembersTable < ActiveRecord::Migration[5.0]
-  def change
+  def up
     drop_table :members
+  end
+
+  def down
   end
 end


### PR DESCRIPTION
# What
To delete a migration file.

# Why
This is because the file is causing errors. 