### PR TITLE
チャットメンバー削除機能の実装

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -21,7 +21,7 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    @members = Group.find(params[:id]).users
+    @members = Group.find(params[:id]).users.where.not(id: current_user.id)
   end
 
   def update

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -30,6 +30,8 @@
             .chat-group-user.clearfix{id: "chat-group-user-#{member.id}"}
               %input.chat-group-user-input{name: "group[user_ids][]", type: "hidden", value: "#{member.id}"}
               %p.chat-group-user__name= member.name
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -23,6 +23,9 @@
     .chat-group-form__field--right
       #chat-group-users
         - if @members
+          .chat-group-user.clearfix{id: "chat-group-user-#{current_user.id}"}
+            %input.chat-group-user-input{name: "group[user_ids][]", type: "hidden", value: "#{current_user.id}"}
+            %p.chat-group-user__name= current_user.name
           - @members.each do |member|
             .chat-group-user.clearfix{id: "chat-group-user-#{member.id}"}
               %input.chat-group-user-input{name: "group[user_ids][]", type: "hidden", value: "#{member.id}"}


### PR DESCRIPTION
# What
チャットメンバー編集画面で、任意のメンバーを削除する機能を実装する。

# Why
ユーザーがチャットグループのメンバーを任意のユーザーを削除できるようにするため。