### PR TITLE
エラーの解決

### DIFF
--- a/app/assets/javascripts/channels/message.js
+++ b/app/assets/javascripts/channels/message.js
@@ -1,7 +1,7 @@
 $(function(){
   function buildNewMessageHTML(message){
     var img = "";
-    if (message.image && message.image["url"] !== null) {
+    if (message.image["url"] !== null) {
         img = `<img class="message__lower-image" src="${message.image.url}">`;
     }
     var html = `<div class="message" data-id="${message.id}">

--- a/app/assets/javascripts/channels/message.js
+++ b/app/assets/javascripts/channels/message.js
@@ -56,12 +56,14 @@ $(function(){
 
   $('#new_message').on('submit', function(e){
     e.preventDefault();
-    var formData = new FormData(this);
-    var url = $(this).attr('action');
-    if ($('#message_body').val() == "" && $('#file-input')[0].files['length'] == 0) {
+
+    if ($('#message_body').val() == "" && $('#file-input')[0].files[0] == null) {
       alert('メッセージを入力してください');
       return;
     }
+
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
 
     $.ajax({
       url: url,

--- a/app/assets/javascripts/channels/message.js
+++ b/app/assets/javascripts/channels/message.js
@@ -1,6 +1,5 @@
 $(function(){
   function buildNewMessageHTML(message){
-
     var img = "";
     if (message.image && message.image["url"] !== null) {
         img = `<img class="message__lower-image" src="${message.image.url}">`;

--- a/app/assets/javascripts/channels/message.js
+++ b/app/assets/javascripts/channels/message.js
@@ -58,6 +58,10 @@ $(function(){
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr('action');
+    if ($('#message_body').val() == "" && $('#file-input')[0].files['length'] == 0) {
+      alert('メッセージを入力してください');
+      return;
+    }
 
     $.ajax({
       url: url,

--- a/app/assets/javascripts/channels/message.js
+++ b/app/assets/javascripts/channels/message.js
@@ -69,7 +69,6 @@ $(function(){
       contentType: false
     })
     .done(function(message){
-      var html = buildNewMessageHTML(message);
       appendNewMessageHTML(message);
       $('.chat-main__footer-form-text').val('');
       changeMessageFormStyle("type a message", "black");

--- a/app/assets/javascripts/channels/message.js
+++ b/app/assets/javascripts/channels/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildNewMessageHTML(message){
 
     var img = "";
-    if (message.image["url"] !== null) {
+    if (message.image && message.image["url"] !== null) {
         img = `<img class="message__lower-image" src="${message.image.url}">`;
     }
     var html = `<div class="message" data-id="${message.id}">

--- a/app/assets/javascripts/channels/message.js
+++ b/app/assets/javascripts/channels/message.js
@@ -59,6 +59,7 @@ $(function(){
 
     if ($('#message_body').val() == "" && $('#file-input')[0].files[0] == null) {
       alert('メッセージを入力してください');
+      location.reload();
       return;
     }
 


### PR DESCRIPTION
# What
空のメッセージを送信したときに、 検証ツールのコンソール上に出るエラーを解決する。

エラー分；
TypeError: Cannot read property 'url' of undefined
    at buildNewMessageHTML (message.self-017cfc9e7e2fa08f176b79296f5cdcc0ebde364cdaa7645b5ac4a8cb80463902.js?body=1:5)

# Why
エラーを解決するため。