### PR TITLE
Groupコントローラのnewアクションの編集する

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -8,7 +8,6 @@ class GroupsController < ApplicationController
   def new
     @group = Group.new
     @members = @group.users
-    @members << current_user
   end
 
   def create


### PR DESCRIPTION
# What
Groupコントローラのnewアクションにある以下の行を削除する。

@members << current_user

# Why
新規グループ作成画面でカレントユーザーが2度表示されてしまっているため。